### PR TITLE
Add handling of dataSource with push notifications support

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -65,6 +65,17 @@ function create(origOpts = {}) {
       }
       ngf._config._source = source;
       model = new SyncModel({ source, onChange, cache }).batch();
+
+      if(source.onPushNotifications) {
+        source.onPushNotifications((data) => {
+          let cache = model.withoutDataSource().set(data);
+          cache.then(() => {
+            cache.model.invalidate();
+            onChange();
+          });
+        });
+      }
+
       $rootScope.$evalAsync();
     };
 

--- a/src/index.js
+++ b/src/index.js
@@ -65,21 +65,20 @@ function create(origOpts = {}) {
       }
       ngf._config._source = source;
       model = new SyncModel({ source, onChange, cache }).batch();
-
-      if(source.onPushNotifications) {
-        source.onPushNotifications((data) => {
-          let cache = model.withoutDataSource().set(data);
-          cache.then(() => {
-            cache.model.invalidate();
-            onChange();
-          });
-        });
-      }
-
       $rootScope.$evalAsync();
     };
 
     ngf.configure(origOpts);
+
+    ngf.pushDataChangesToCache = function(data) {
+      if(data) {
+        let cacheResponse = model.withoutDataSource().set(data);
+        cacheResponse.then(() => {
+          cacheResponse.model.invalidate();
+          onChange();
+        });
+      }
+    };
 
     // proxy the model on this object
     for (const [ srcName, destName ] of [


### PR DESCRIPTION
It's more a "what do you think of this approach" kind of pull request. Since the support for push notifications is datasource dependant, but the datasource isn't aware of the model, I think it could be a good way of adding this feature. The code is based on this recommendation [#751](https://github.com/Netflix/falcor/issues/751). Any thoughts?