### PR TITLE
Add missing parameters for falcor model configuration

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -46,18 +46,20 @@ function create(origOpts = {}) {
         ? assign({}, opts.headers, newOpts.headers)
         : undefined;
       const cache = newOpts.cache || undefined;
-      let router, timeout, source;
+      let router, timeout, source, errorSelector;
       if (newOpts.router !== undefined) { router = router || undefined; }
       else { router = opts.router; }
       if (newOpts.timeout !== undefined) { timeout = timeout || undefined; }
       else { timeout = opts.timeout; }
       if (newOpts.source !== undefined) { source = source || undefined; }
       else { source = opts.source; }
-      const finalOpts = { headers, cache, router, timeout, source };
+      if (newOpts.errorSelector !== undefined) { errorSelector = errorSelector || undefined; }
+      else { errorSelector = opts.errorSelector; }
+      const finalOpts = { headers, cache, router, timeout, source, errorSelector };
       ngf.configure(finalOpts);
     };
 
-    ngf.configure = function({ source, router, timeout, headers, cache } = {}) {
+    ngf.configure = function({ source, router, timeout, headers, cache, errorSelector } = {}) {
       //if(headers === undefined) headers = {};
       ngf._config = arguments[0];
       delete ngf._config.cache;
@@ -65,7 +67,7 @@ function create(origOpts = {}) {
         source = new HttpDataSource(router, { timeout, headers });
       }
       ngf._config._source = source;
-      model = new SyncModel({ source, onChange, cache }).batch();
+      model = new SyncModel({ source, onChange, cache, errorSelector }).batch();
       $rootScope.$evalAsync();
     };
 

--- a/src/index.js
+++ b/src/index.js
@@ -42,32 +42,22 @@ function create(origOpts = {}) {
 
     ngf.reconfigure = function(newOpts = {}) {
       const opts = ngf._config;
-      const headers = newOpts.headers === undefined || newOpts.headers
-        ? assign({}, opts.headers, newOpts.headers)
-        : undefined;
-      const cache = newOpts.cache || undefined;
-      let router, timeout, source, errorSelector;
-      if (newOpts.router !== undefined) { router = router || undefined; }
-      else { router = opts.router; }
-      if (newOpts.timeout !== undefined) { timeout = timeout || undefined; }
-      else { timeout = opts.timeout; }
-      if (newOpts.source !== undefined) { source = source || undefined; }
-      else { source = opts.source; }
-      if (newOpts.errorSelector !== undefined) { errorSelector = errorSelector || undefined; }
-      else { errorSelector = opts.errorSelector; }
-      const finalOpts = { headers, cache, router, timeout, source, errorSelector };
+      const finalOpts = removeUndef(assign({}, opts, newOpts));
+      finalOpts.cache = newOpts.cache || undefined;
+      finalOpts.headers = newOpts.headers === undefined || newOpts.headers
+          ? assign({}, opts.headers, newOpts.headers)
+          : {};
       ngf.configure(finalOpts);
     };
 
-    ngf.configure = function({ source, router, timeout, headers, cache, errorSelector } = {}) {
-      //if(headers === undefined) headers = {};
-      ngf._config = arguments[0];
+    ngf.configure = function({ source, router, timeout, headers, cache, maxSize, collectRatio, comparator, errorSelector } = {}) {
+      ngf._config = removeUndef(arguments[0]);
       delete ngf._config.cache;
       if (!source && router) {
-        source = new HttpDataSource(router, { timeout, headers });
+        source = new HttpDataSource(router, removeUndef({ timeout, headers }));
       }
       ngf._config._source = source;
-      model = new SyncModel({ source, onChange, cache, errorSelector }).batch();
+      model = new SyncModel(removeUndef({ source, onChange, cache, maxSize, collectRatio, comparator, errorSelector })).batch();
       $rootScope.$evalAsync();
     };
 
@@ -164,6 +154,11 @@ function noUndef(path) {
     }
   }
   return true;
+}
+
+function removeUndef(o) {
+  Object.keys(o).forEach(function(i) { if(o[i] === undefined || o[i] === null) delete o[i]; });
+  return o;
 }
 
 module.exports = { create };

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -219,11 +219,11 @@ describe('ng-falcor', () => {
       assert.strictEqual(ngf._config.router, undefined);
     });
 
-    it('should reconfigure headers set null', () => {
+    it('should reconfigure headers set empty', () => {
       const factory = create({ headers: { foo: 'bar' } });
       const ngf = factory($rootScope);
       ngf.reconfigure({ headers: null });
-      assert.strictEqual(ngf._config.headers, undefined);
+      assert.deepEqual(ngf._config.headers, {});
     });
 
     it('should not keep ref to cache', () => {


### PR DESCRIPTION
There was a couple of missing parameter... 

- maxSize
- collectRatio
- onChange
- comparator

And I readd the fix for the empty headers forced to undefined, because there's an impedance mismatch betweet the way ng-falcor unset a parameter vs falcor.

```javascript
var config = {
      method: method || 'GET',
      crossDomain: false,
      async: true,
      headers: {},
      responseType: 'json'
    };

    var xhr,
      isDone,
      headers,
      header,
      prop;

    for (prop in options) {
      if (hasOwnProp.call(options, prop)) {
        config[prop] = options[prop];
      }
    }
```

The unit tests still pass