### PR TITLE
Add ability to get the raw, underlying Falcor Model

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -136,6 +136,10 @@ function create(origOpts = {}) {
     ngf.atom = falcor.Model.atom;
     ngf.error = falcor.Model.error;
 
+    ngf.rawModel = function() {
+      return model;
+    };
+
     // All done.
     return ngf;
   }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -52,6 +52,21 @@ describe('ng-falcor', () => {
       assert.strictEqual(typeof ngf, 'function');
     });
 
+    it('rawModel should be a function', () => {
+      const factory = create({});
+      const ngf = factory($rootScope);
+      assert.strictEqual(typeof ngf.rawModel, 'function');
+    });
+
+    it('rawModel should return a Falcor model', () => {
+      const factory = create({});
+      const ngf = factory($rootScope);
+      const rawModel = ngf.rawModel();
+      assert.ok(rawModel instanceof Model, 'is an instance of a Falcor Model');
+      assert.strictEqual(typeof rawModel.get, 'function', 'has a get method');
+      assert.strictEqual(typeof rawModel.set, 'function', 'has a set method');
+    });
+
     it('getValue should be a function', () => {
       const factory = create({});
       const ngf = factory($rootScope);


### PR DESCRIPTION
This PR exposes the underlying Falcor Model through a `rawModel()` method on the `ngf` object. Please let me know if I missed the mark when it comes to test structure, library API, etc. Thanks!