### PR TITLE
Add hook into Model onChange event

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,12 @@ function create(origOpts = {}) {
   function factory($rootScope) {
 
     // Called whenever model changes.
-    const onChange = () => { $rootScope.$evalAsync(); };
+    const onChange = () => {
+      if(typeof origOpts.onChange === 'function') {
+        origOpts.onChange();
+      }
+      $rootScope.$evalAsync();
+    };
 
     // Central cache of data shared by all ngf consumers.
     let model;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -29,6 +29,17 @@ describe('ng-falcor', () => {
     it('should create', () => {
       create({});
     });
+
+    it('should create with onChange option', () => {
+      let handled = false;
+      const handleChange = () => {
+        handled = true;
+      };
+      const factory = create({onChange: handleChange});
+      const ngf = factory($rootScope);
+      ngf.rawModel()._root.onChange();
+      assert.strictEqual(handled, true);
+    });
   });
 
   describe('factory', () => {


### PR DESCRIPTION
Allow users of ng-falcor to subscribe to changes in the Falcor Model cache.

Code sample:
```
ngFalcor.create({
  router: '/api/model.json',
  onChange: function () {
    console.log('Handle changes here');
  }
});
```